### PR TITLE
ISDK-473: Fix an issue where Picture-in-Picture does not work for video feed with FireworkVideoSDK 1.3.0 and later.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1]
+
+### Changed
+
+  - Fixes issue where Picture-in-Picture does not work with FireworkVideoSDK 1.3.0 and later.
+
 ## [0.3.0]
 
 ### Changed

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "FireworkVideoIVSSupport",
-            url: "https://github.com/loopsocial/firework_ios_sdk_ivs_support/releases/download/v0.3.0/FireworkVideoIVSSupport.xcframework.zip",
-            checksum: "97ed47d80b0b933575a17999d2a0bae0a862e1bd1e08e11e799b05ce1e9ed557"
+            url: "https://github.com/loopsocial/firework_ios_sdk_ivs_support/releases/download/v0.3.1/FireworkVideoIVSSupport.xcframework.zip",
+            checksum: "d1092c4ff915433386b363ce205a3ce4a02e774b7245fd1340ec10958894103c"
         )
     ]
 )


### PR DESCRIPTION
## Objective :dart:
  * Ticket: [[ISDK-473](https://fwn.atlassian.net/browse/ISDK-473)]
  
## Changes :boom:
  * Fix an issue where Picture-in-Picture does not work for video feed with FireworkVideoSDK 1.3.0 and later.
  * Update Changelog, ReadMe and Package files..
  * Draft Release is [here](https://github.com/loopsocial/firework_ios_sdk_ivs_support/releases)
 
## Survey :clipboard:

### Type of Pull Request 

 - [ ] Feature
 - [ ] Enhancements
 - [x] Bug Fix
 - [ ] Maintenance (Code refactoring)

### All Features, Enhancements, Bug Fixes, or Maintenance work
 - [ ] Includes Unit Tests

### Changes to public API or documented SDK behavior
 - [ ] Adds documentation (Required for `public` or `open` APIs)
 - [ ] Do these changes break public API?
 - [x] [CHANGELOG](https://github.com/loopsocial/firework_ios_sdk_ivs_support/blob/main/CHANGELOG.md) updated for any SDK user-facing changes
 - [x] [README](https://github.com/loopsocial/firework_ios_sdk_ivs_support/blob/main/README.md) updated for any SDK-user facing changes
 - [ ] [Sample Project](https://github.com/loopsocial/corellia/blob/main/public-resources/FireworkVideoSample) updated for any SDK-user facing changes (optional for large or complex changes)

## Callout :raised_hand:
