### PR TITLE
ISDK-1104: Update binary to match FireworkSDK 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0]
+
+### Changed
+
+  - Updates binary to sync with FireworkVideoSDK 1.10.0.
+
+## [0.5.0]
+
+### Changed
+
+  - Includes IVS supporting libs to SPM.
+
 ## [0.4.0]
 
 ### Added

--- a/FireworkVideoIVSSupport.podspec
+++ b/FireworkVideoIVSSupport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'FireworkVideoIVSSupport'
-    s.version          = '0.4.0'
+    s.version          = '0.6.0'
     s.summary          = 'FireworkVideoIVSSupport'
   
     s.homepage         = 'https://github.com/loopsocial/firework_ios_sdk_ivs_support'

--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "FireworkVideoIVSSupport",
-            url: "https://github.com/loopsocial/firework_ios_sdk_ivs_support/releases/download/v0.5.0/FireworkVideoIVSSupport-v0.5.0.xcframework.zip",
-            checksum: "477568277138b338a6dbaf2bf0ebd3961ddce138a844279724cf0bf8ce004ff7"
+            url: "https://github.com/loopsocial/firework_ios_sdk_ivs_support/releases/download/v0.6.0/FireworkVideoIVSSupport-v0.6.0.xcframework.zip",
+            checksum: "de573ede9467185d592c2e410ee07620f9885ad5d5b7e7edf0abba772b23ce63"
         ),
         .target(
             name: "FireworkVideoIVSSupportDependencies",


### PR DESCRIPTION
## Objective :dart:
  * Ticket: [ISDK-1104](https://fwn.atlassian.net/browse/ISDK-1104)
  
## Changes :boom:
  * New release binary to match FireworkSDK 1.10.0.
  * Update Changelog, Package.swift and podspec files
  * [Draft Release](https://github.com/loopsocial/firework_ios_sdk_ivs_support/releases/tag/untagged-1b6fdb0503332bd42d5d)
 
## Survey :clipboard:

### Type of Pull Request 

 - [ ] Feature
 - [ ] Enhancements
 - [x] Bug Fix
 - [ ] Maintenance (Code refactoring)

### All Features, Enhancements, Bug Fixes, or Maintenance work
 - [ ] Includes Unit Tests

### Changes to public API or documented SDK behavior
 - [ ] Adds documentation (Required for `public` or `open` APIs)
 - [ ] Do these changes break public API?
 - [x] [CHANGELOG](https://github.com/loopsocial/firework_ios_sdk_ivs_support/blob/main/CHANGELOG.md) updated for any SDK user-facing changes
 - [ ] [README](https://github.com/loopsocial/firework_ios_sdk_ivs_support/blob/main/README.md) updated for any SDK-user facing changes
 - [ ] [Sample Project](https://github.com/loopsocial/corellia/blob/main/public-resources/FireworkVideoSample) updated for any SDK-user facing changes (optional for large or complex changes)

## Callout :raised_hand:


[ISDK-1104]: https://fwn.atlassian.net/browse/ISDK-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ